### PR TITLE
Dedupe fix

### DIFF
--- a/download/common.go
+++ b/download/common.go
@@ -27,10 +27,11 @@ const maximumWaitBetweenDownloadAttempts = time.Minute * time.Duration(8)
 // parameters to be passed through runFunctionWithRetry to the
 // download function.
 type DownloadConfig struct {
-	URL       string         // The URL of the file to download
-	Store     file.FileStore // The FileStore in which to place the file
-	Prefix    string         // The prefix to append to the file name after it's downloaded
-	URLRegexp *regexp.Regexp // The regular expression to apply to the URL to create the filename.
+	URL        string         // The URL of the file to download
+	Store      file.FileStore // The FileStore in which to place the file
+	PathPrefix string         // The prefix to attach to the file's path after it's downloaded
+	FilePrefix string         // The prefix to attach to the filename after it's downloaded
+	URLRegexp  *regexp.Regexp // The regular expression to apply to the URL to create the filename.
 	// The first matching group will go before the timestamp, the second after.
 	DedupeRegexp *regexp.Regexp // The regexp to apply to the filename to determine the directory to dedupe in.
 }
@@ -74,9 +75,8 @@ func Download(config interface{}) (error, bool) {
 	}
 
 	// Get a handle on our object in GCS where we will store the file
-	timestamp := time.Now().UTC().Format("20060102T150402Z-")
 	urlMatches := dc.URLRegexp.FindAllStringSubmatch(dc.URL, -1)
-	filename := dc.Prefix + urlMatches[0][1] + timestamp + urlMatches[0][2]
+	filename := dc.PathPrefix + urlMatches[0][1] + dc.FilePrefix + urlMatches[0][2]
 	obj := dc.Store.GetFile(filename)
 	w := obj.GetWriter()
 

--- a/download/common.go
+++ b/download/common.go
@@ -74,7 +74,7 @@ func Download(config interface{}) (error, bool) {
 	}
 
 	// Get a handle on our object in GCS where we will store the file
-	timestamp := time.Now().UTC().Format("20060102T150402Z")
+	timestamp := time.Now().UTC().Format("20060102T150402Z-")
 	urlMatches := dc.URLRegexp.FindAllStringSubmatch(dc.URL, -1)
 	filename := dc.Prefix + urlMatches[0][1] + timestamp + urlMatches[0][2]
 	obj := dc.Store.GetFile(filename)

--- a/download/common.go
+++ b/download/common.go
@@ -17,10 +17,10 @@ import (
 
 // The time (in minutes) to wait before the first retry of a failed
 // download
-const waitAfterFirstDownloadFailure = time.Minute * time.Duration(1)
+var WaitAfterFirstDownloadFailure = time.Minute * time.Duration(1)
 
 // The maximum time (in minutes) to wait in between download attempts
-const maximumWaitBetweenDownloadAttempts = time.Minute * time.Duration(8)
+var MaximumWaitBetweenDownloadAttempts = time.Minute * time.Duration(8)
 
 // TODO(JosephMarques): Find a better method than using
 // backChars. Possibly regex?  downloadConfig is a struct for bundling

--- a/download/common_test.go
+++ b/download/common_test.go
@@ -103,7 +103,7 @@ func Test_download(t *testing.T) {
 			dc: d.DownloadConfig{
 				URL:          "Fill me",
 				Store:        &testStore{map[string]testFileObject{}},
-				Prefix:       "pre/",
+				PathPrefix:   "pre/",
 				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
 				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},
@@ -115,7 +115,7 @@ func Test_download(t *testing.T) {
 			dc: d.DownloadConfig{
 				URL:          "Fill me",
 				Store:        &testStore{map[string]testFileObject{}},
-				Prefix:       "pre/",
+				PathPrefix:   "pre/",
 				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
 				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},
@@ -127,7 +127,7 @@ func Test_download(t *testing.T) {
 			dc: d.DownloadConfig{
 				URL:          "Fill me",
 				Store:        &testStore{map[string]testFileObject{}},
-				Prefix:       "pre/",
+				PathPrefix:   "pre/",
 				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
 				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},
@@ -141,7 +141,7 @@ func Test_download(t *testing.T) {
 				Store: &testStore{map[string]testFileObject{
 					"pre/file.del/dup": testFileObject{name: "pre/file.del/dup", data: bytes.NewBuffer(nil), md5: []byte("NEW FILE")},
 				}},
-				Prefix:       "pre/",
+				PathPrefix:   "pre/",
 				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
 				DedupeRegexp: regexp.MustCompile(`(pre/)`),
 			},
@@ -153,7 +153,7 @@ func Test_download(t *testing.T) {
 			dc: d.DownloadConfig{
 				URL:          "Fill me",
 				Store:        &testStore{map[string]testFileObject{}},
-				Prefix:       "pre/",
+				PathPrefix:   "pre/",
 				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
 				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},

--- a/download/common_test.go
+++ b/download/common_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -100,10 +101,11 @@ func Test_download(t *testing.T) {
 	}{
 		{
 			dc: d.DownloadConfig{
-				URL:       "Fill me",
-				Store:     &testStore{map[string]testFileObject{}},
-				Prefix:    "pre/",
-				BackChars: 0,
+				URL:          "Fill me",
+				Store:        &testStore{map[string]testFileObject{}},
+				Prefix:       "pre/",
+				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
+				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},
 			postfix: "portGarbage",
 			resBool: false,
@@ -111,10 +113,11 @@ func Test_download(t *testing.T) {
 		},
 		{
 			dc: d.DownloadConfig{
-				URL:       "Fill me",
-				Store:     &testStore{map[string]testFileObject{}},
-				Prefix:    "pre/",
-				BackChars: 0,
+				URL:          "Fill me",
+				Store:        &testStore{map[string]testFileObject{}},
+				Prefix:       "pre/",
+				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
+				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},
 			postfix: "/file.error",
 			resBool: false,
@@ -122,10 +125,11 @@ func Test_download(t *testing.T) {
 		},
 		{
 			dc: d.DownloadConfig{
-				URL:       "Fill me",
-				Store:     &testStore{map[string]testFileObject{}},
-				Prefix:    "pre/",
-				BackChars: 0,
+				URL:          "Fill me",
+				Store:        &testStore{map[string]testFileObject{}},
+				Prefix:       "pre/",
+				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
+				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},
 			postfix: "/file.copyFail",
 			resBool: false,
@@ -137,8 +141,9 @@ func Test_download(t *testing.T) {
 				Store: &testStore{map[string]testFileObject{
 					"pre/file.del/dup": testFileObject{name: "pre/file.del/dup", data: bytes.NewBuffer(nil), md5: []byte("NEW FILE")},
 				}},
-				Prefix:    "pre/",
-				BackChars: 0,
+				Prefix:       "pre/",
+				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
+				DedupeRegexp: regexp.MustCompile(`(pre/)`),
 			},
 			postfix: "/file.deleteFail",
 			resBool: true,
@@ -146,10 +151,11 @@ func Test_download(t *testing.T) {
 		},
 		{
 			dc: d.DownloadConfig{
-				URL:       "Fill me",
-				Store:     &testStore{map[string]testFileObject{}},
-				Prefix:    "pre/",
-				BackChars: 0,
+				URL:          "Fill me",
+				Store:        &testStore{map[string]testFileObject{}},
+				Prefix:       "pre/",
+				URLRegexp:    regexp.MustCompile(`.*()(/.*)`),
+				DedupeRegexp: regexp.MustCompile(`(.*)`),
 			},
 			postfix: "/file.success",
 			resBool: false,

--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -1,10 +1,15 @@
 package download
 
 import (
+	"regexp"
+
 	"github.com/m-lab/downloader/file"
 	"github.com/m-lab/downloader/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+var maxmindURLToFilenameRegexp = regexp.MustCompile(`.*/()(.*)`)
+var maxmindFilenameToDedupeRegexp = regexp.MustCompile(`(.*/).*/.*`)
 
 // The list of URLs to download from Maxmind
 var MaxmindURLs []string = []string{
@@ -29,7 +34,8 @@ var MaxmindURLs []string = []string{
 func DownloadMaxmindFiles(urls []string, timestamp string, store file.FileStore) error {
 	var lastErr error = nil
 	for _, url := range urls {
-		dc := DownloadConfig{URL: url, Store: store, Prefix: "Maxmind/" + timestamp, BackChars: 0}
+		dc := DownloadConfig{URL: url, Store: store, Prefix: "Maxmind/" + timestamp,
+			URLRegexp: maxmindURLToFilenameRegexp, DedupeRegexp: maxmindFilenameToDedupeRegexp}
 		if err := RunFunctionWithRetry(Download, dc, waitAfterFirstDownloadFailure,
 			maximumWaitBetweenDownloadAttempts); err != nil {
 

--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -40,7 +40,6 @@ func DownloadMaxmindFiles(urls []string, timestamp string, store file.FileStore)
 			DedupeRegexp: maxmindFilenameToDedupeRegexp}
 		if err := RunFunctionWithRetry(Download, dc, WaitAfterFirstDownloadFailure,
 			MaximumWaitBetweenDownloadAttempts); err != nil {
-
 			lastErr = err
 			metrics.FailedDownloadCount.With(prometheus.Labels{"download_type": "Maxmind"}).Inc()
 		}

--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -38,8 +38,8 @@ func DownloadMaxmindFiles(urls []string, timestamp string, store file.FileStore)
 		dc := DownloadConfig{URL: url, Store: store, PathPrefix: "Maxmind/" + timestamp,
 			FilePrefix: time.Now().UTC().Format("20060102T150402Z-"), URLRegexp: maxmindURLToFilenameRegexp,
 			DedupeRegexp: maxmindFilenameToDedupeRegexp}
-		if err := RunFunctionWithRetry(Download, dc, waitAfterFirstDownloadFailure,
-			maximumWaitBetweenDownloadAttempts); err != nil {
+		if err := RunFunctionWithRetry(Download, dc, WaitAfterFirstDownloadFailure,
+			MaximumWaitBetweenDownloadAttempts); err != nil {
 
 			lastErr = err
 			metrics.FailedDownloadCount.With(prometheus.Labels{"download_type": "Maxmind"}).Inc()

--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"regexp"
+	"time"
 
 	"github.com/m-lab/downloader/file"
 	"github.com/m-lab/downloader/metrics"
@@ -34,8 +35,9 @@ var MaxmindURLs []string = []string{
 func DownloadMaxmindFiles(urls []string, timestamp string, store file.FileStore) error {
 	var lastErr error = nil
 	for _, url := range urls {
-		dc := DownloadConfig{URL: url, Store: store, Prefix: "Maxmind/" + timestamp,
-			URLRegexp: maxmindURLToFilenameRegexp, DedupeRegexp: maxmindFilenameToDedupeRegexp}
+		dc := DownloadConfig{URL: url, Store: store, PathPrefix: "Maxmind/" + timestamp,
+			FilePrefix: time.Now().UTC().Format("20060102T150402Z-"), URLRegexp: maxmindURLToFilenameRegexp,
+			DedupeRegexp: maxmindFilenameToDedupeRegexp}
 		if err := RunFunctionWithRetry(Download, dc, waitAfterFirstDownloadFailure,
 			maximumWaitBetweenDownloadAttempts); err != nil {
 

--- a/download/maxmind_test.go
+++ b/download/maxmind_test.go
@@ -42,7 +42,7 @@ func TestDownloadMaxmindFiles(t *testing.T) {
 	for _, test := range tests {
 		res := d.DownloadMaxmindFiles(test.urls, test.timestamp, test.fsto)
 		if (res == nil && test.res != nil) || (res != nil && test.res == nil) {
-			t.Errorf("Expected %t, got %t for %+v\n\n, file sto: %+v, fstoaddr: ", test.res, res, test, test.fsto, &test.fsto)
+			t.Errorf("Expected %s, got %s for %+v\n\n, file sto: %+v, fstoaddr: ", test.res, res, test, test.fsto, &test.fsto)
 		}
 	}
 

--- a/download/routeviews.go
+++ b/download/routeviews.go
@@ -40,7 +40,6 @@ func DownloadCaidaRouteviewsFiles(logFileURL string, directory string, lastDownl
 		return err
 	}
 	for _, urlAndID := range routeViewsURLsAndIDs {
-		// TODO(JosephMarques): Restructure entire backchars/dedupe system. It just doesn't work well at the moment. Some sort of selection and regex function.
 		dc := DownloadConfig{URL: urlAndID.URL, Store: store, PathPrefix: directory, FilePrefix: "",
 			URLRegexp: routeviewsURLToFilenameRegexp, DedupeRegexp: routeviewsFilenameToDedupeRegexp}
 		if err := RunFunctionWithRetry(Download, dc, WaitAfterFirstDownloadFailure,

--- a/download/routeviews.go
+++ b/download/routeviews.go
@@ -38,7 +38,7 @@ func DownloadCaidaRouteviewsFiles(logFileURL string, directory string, lastDownl
 	}
 	for _, urlAndID := range routeViewsURLsAndIDs {
 		// TODO(JosephMarques): Restructure entire backchars/dedupe system. It just doesn't work well at the moment. Some sort of selection and regex function.
-		dc := DownloadConfig{URL: urlAndID.URL, Store: store, Prefix: directory,
+		dc := DownloadConfig{URL: urlAndID.URL, Store: store, PathPrefix: directory, FilePrefix: "",
 			URLRegexp: routeviewsURLToFilenameRegexp, DedupeRegexp: routeviewsFilenameToDedupeRegexp}
 		if err := RunFunctionWithRetry(Download, dc, waitAfterFirstDownloadFailure,
 			maximumWaitBetweenDownloadAttempts); err != nil {

--- a/download/routeviews.go
+++ b/download/routeviews.go
@@ -45,7 +45,6 @@ func DownloadCaidaRouteviewsFiles(logFileURL string, directory string, lastDownl
 			URLRegexp: routeviewsURLToFilenameRegexp, DedupeRegexp: routeviewsFilenameToDedupeRegexp}
 		if err := RunFunctionWithRetry(Download, dc, WaitAfterFirstDownloadFailure,
 			MaximumWaitBetweenDownloadAttempts); err != nil {
-
 			lastErr = err
 			metrics.FailedDownloadCount.With(prometheus.Labels{"download_type": directory}).Inc()
 		}

--- a/download/routeviews.go
+++ b/download/routeviews.go
@@ -40,8 +40,8 @@ func DownloadCaidaRouteviewsFiles(logFileURL string, directory string, lastDownl
 		// TODO(JosephMarques): Restructure entire backchars/dedupe system. It just doesn't work well at the moment. Some sort of selection and regex function.
 		dc := DownloadConfig{URL: urlAndID.URL, Store: store, PathPrefix: directory, FilePrefix: "",
 			URLRegexp: routeviewsURLToFilenameRegexp, DedupeRegexp: routeviewsFilenameToDedupeRegexp}
-		if err := RunFunctionWithRetry(Download, dc, waitAfterFirstDownloadFailure,
-			maximumWaitBetweenDownloadAttempts); err != nil {
+		if err := RunFunctionWithRetry(Download, dc, WaitAfterFirstDownloadFailure,
+			MaximumWaitBetweenDownloadAttempts); err != nil {
 
 			lastErr = err
 			metrics.FailedDownloadCount.With(prometheus.Labels{"download_type": directory}).Inc()

--- a/download/routeviews_test.go
+++ b/download/routeviews_test.go
@@ -30,23 +30,24 @@ func TestDownloadCaidaRouteviewsFiles(t *testing.T) {
 			fsto:    &testStore{map[string]testFileObject{}},
 			res:     nil,
 		},
-		/*{
+		{
 			logFile: "/logFile2",
 			dir:     "test2/",
 			lastD:   0,
 			lastS:   3364,
 			fsto:    &testStore{map[string]testFileObject{}},
-			res:     errors.New(""),
-		},*/
+			res:     errors.New("2"),
+		},
 		{
 			logFile: "portGarbage",
 			dir:     "test3/",
 			lastD:   0,
 			lastS:   0,
 			fsto:    &testStore{map[string]testFileObject{}},
-			res:     errors.New(""),
+			res:     errors.New("3"),
 		},
 	}
+	d.MaximumWaitBetweenDownloadAttempts = 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if strings.HasSuffix(path, "logFile1") {
@@ -67,9 +68,9 @@ func TestDownloadCaidaRouteviewsFiles(t *testing.T) {
 3364	1497803191	2017/06/routeviews-rv2-20170617-1200.pfx2as.gz
 3365	1497889838	2018/06/routeviews-rv2-20170617-1000.pfx2as.gz`)
 			return
-		} /*
-					if strings.HasSuffix(path, "logFile2") {
-						fmt.Fprint(w, `# Format: 1
+		}
+		if strings.HasSuffix(path, "logFile2") {
+			fmt.Fprint(w, `# Format: 1
 			# Fields: seqnum timestamp path
 			# Generated: 2017-07-16 09:26:29 -0700
 			# --------------------------------------------------------------------------
@@ -84,9 +85,9 @@ func TestDownloadCaidaRouteviewsFiles(t *testing.T) {
 			# --------------------------------------------------------------------------
 			3363	1497717708	2017/06/routeviews-rv2-20170616-1200.pfx2as.gz
 			3364	1497803191	2017/06/routeviews-rv2-20170617-1200.pfx2as.gz
-			3365	1497889838	2017/06/deleteFail`)
-						return
-					}*/
+			3365	1497889838	2017/06/copyFail`)
+			return
+		}
 		fmt.Fprint(w, r.URL.String())
 	}))
 	for _, test := range tests {

--- a/download/routeviews_test.go
+++ b/download/routeviews_test.go
@@ -71,21 +71,21 @@ func TestDownloadCaidaRouteviewsFiles(t *testing.T) {
 		}
 		if strings.HasSuffix(path, "logFile2") {
 			fmt.Fprint(w, `# Format: 1
-			# Fields: seqnum timestamp path
-			# Generated: 2017-07-16 09:26:29 -0700
-			# --------------------------------------------------------------------------
-			# Check this log regularly (once or twice a day) to keep up with the
-			# generation of daily files.  The easiest way to find the newest files is
-			# to compare the last seqnum you downloaded to the seqnum of all entries.
-			#
-			# The timestamp column gives the time that a daily pfx2as file was
-			# generated.  Please note that the timestamp will _not_ necessarily match
-			# the date in the filename, since file generation intentionally lags behind
-			# a bit.
-			# --------------------------------------------------------------------------
-			3363	1497717708	2017/06/routeviews-rv2-20170616-1200.pfx2as.gz
-			3364	1497803191	2017/06/routeviews-rv2-20170617-1200.pfx2as.gz
-			3365	1497889838	2017/06/copyFail`)
+# Fields: seqnum timestamp path
+# Generated: 2017-07-16 09:26:29 -0700
+# --------------------------------------------------------------------------
+# Check this log regularly (once or twice a day) to keep up with the
+# generation of daily files.  The easiest way to find the newest files is
+# to compare the last seqnum you downloaded to the seqnum of all entries.
+#
+# The timestamp column gives the time that a daily pfx2as file was
+# generated.  Please note that the timestamp will _not_ necessarily match
+# the date in the filename, since file generation intentionally lags behind
+# a bit.
+# --------------------------------------------------------------------------
+3363	1497717708	2017/06/routeviews-rv2-20170616-1200.pfx2as.gz
+3364	1497803191	2017/06/routeviews-rv2-20170617-1200.pfx2as.gz
+3365	1497889838	2017/06/copyFail`)
 			return
 		}
 		fmt.Fprint(w, r.URL.String())

--- a/download/routeviews_test.go
+++ b/download/routeviews_test.go
@@ -30,14 +30,14 @@ func TestDownloadCaidaRouteviewsFiles(t *testing.T) {
 			fsto:    &testStore{map[string]testFileObject{}},
 			res:     nil,
 		},
-		{
+		/*{
 			logFile: "/logFile2",
 			dir:     "test2/",
 			lastD:   0,
 			lastS:   3364,
 			fsto:    &testStore{map[string]testFileObject{}},
 			res:     errors.New(""),
-		},
+		},*/
 		{
 			logFile: "portGarbage",
 			dir:     "test3/",
@@ -67,26 +67,26 @@ func TestDownloadCaidaRouteviewsFiles(t *testing.T) {
 3364	1497803191	2017/06/routeviews-rv2-20170617-1200.pfx2as.gz
 3365	1497889838	2018/06/routeviews-rv2-20170617-1000.pfx2as.gz`)
 			return
-		}
-		if strings.HasSuffix(path, "logFile2") {
-			fmt.Fprint(w, `# Format: 1
-# Fields: seqnum timestamp path
-# Generated: 2017-07-16 09:26:29 -0700
-# --------------------------------------------------------------------------
-# Check this log regularly (once or twice a day) to keep up with the
-# generation of daily files.  The easiest way to find the newest files is
-# to compare the last seqnum you downloaded to the seqnum of all entries.
-#
-# The timestamp column gives the time that a daily pfx2as file was
-# generated.  Please note that the timestamp will _not_ necessarily match
-# the date in the filename, since file generation intentionally lags behind
-# a bit.
-# --------------------------------------------------------------------------
-3363	1497717708	2017/06/routeviews-rv2-20170616-1200.pfx2as.gz
-3364	1497803191	2017/06/routeviews-rv2-20170617-1200.pfx2as.gz
-3365	1497889838	2017/06/deleteFail`)
-			return
-		}
+		} /*
+					if strings.HasSuffix(path, "logFile2") {
+						fmt.Fprint(w, `# Format: 1
+			# Fields: seqnum timestamp path
+			# Generated: 2017-07-16 09:26:29 -0700
+			# --------------------------------------------------------------------------
+			# Check this log regularly (once or twice a day) to keep up with the
+			# generation of daily files.  The easiest way to find the newest files is
+			# to compare the last seqnum you downloaded to the seqnum of all entries.
+			#
+			# The timestamp column gives the time that a daily pfx2as file was
+			# generated.  Please note that the timestamp will _not_ necessarily match
+			# the date in the filename, since file generation intentionally lags behind
+			# a bit.
+			# --------------------------------------------------------------------------
+			3363	1497717708	2017/06/routeviews-rv2-20170616-1200.pfx2as.gz
+			3364	1497803191	2017/06/routeviews-rv2-20170617-1200.pfx2as.gz
+			3365	1497889838	2017/06/deleteFail`)
+						return
+					}*/
 		fmt.Fprint(w, r.URL.String())
 	}))
 	for _, test := range tests {

--- a/downloader.go
+++ b/downloader.go
@@ -48,7 +48,7 @@ func loopOverURLsForever(bucketName string) {
 	lastDownloadedV4 := 0
 	lastDownloadedV6 := 0
 	for {
-		timestamp := time.Now().Format("2006/01/02/15:04:05-")
+		timestamp := time.Now().Format("2006/01/02/")
 		bkt, err := constructBucketHandle(bucketName)
 		if err != nil {
 			continue

--- a/downloader.go
+++ b/downloader.go
@@ -16,25 +16,34 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const averageHoursBetweenUpdateChecks = 8 * time.Hour        // The average time (in hours) to wait in between attempts to download files
-const windowForRandomTimeBetweenUpdateChecks = 4 * time.Hour // The window of time (in hours) to allow a random time to be chosen from.
+// The average time (in hours) to wait in between attempts to download
+// files
+const averageHoursBetweenUpdateChecks = 8 * time.Hour
 
-// The main function seeds the random number generator, starts prometheus in the background, takes the bucket flag from the command line, and kicks off the actual downloader loop
+// The window of time (in hours) to allow a random time to be chosen
+// from.
+const windowForRandomTimeBetweenUpdateChecks = 4 * time.Hour
+
+// The main function seeds the random number generator, starts
+// prometheus in the background, takes the bucket flag from the
+// command line, and kicks off the actual downloader loop
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-	metrics.SetupPrometheus()
-	go func() {
-		log.Fatal(http.ListenAndServe(":8080", nil))
-	}()
 	bucketName := flag.String("bucket", "", "Specify the bucket name to store the results in.")
 	flag.Parse()
 	if *bucketName == "" {
 		log.Fatal("NO BUCKET SPECIFIED!!!")
 	}
+	rand.Seed(time.Now().UTC().UnixNano())
+	metrics.SetupPrometheus()
+	go func() {
+		log.Fatal(http.ListenAndServe(":8080", nil))
+	}()
 	loopOverURLsForever(*bucketName)
 }
 
-// loopOverURLsForever takes a bucketName, pointing to a GCS bucket, and then tries to download the files over and over again until the end of time (waiting an average of 8 hours in between attempts)
+// loopOverURLsForever takes a bucketName, pointing to a GCS bucket,
+// and then tries to download the files over and over again until the
+// end of time (waiting an average of 8 hours in between attempts)
 func loopOverURLsForever(bucketName string) {
 	lastDownloadedV4 := 0
 	lastDownloadedV6 := 0
@@ -68,7 +77,8 @@ func loopOverURLsForever(bucketName string) {
 	}
 }
 
-// constructBucketHandle takes a bucket name and safely loads it, returning either the handle to the bucket or an error
+// constructBucketHandle takes a bucket name and safely loads it,
+// returning either the handle to the bucket or an error
 func constructBucketHandle(bucketName string) (*storage.BucketHandle, error) {
 	ctx, _ := context.WithTimeout(context.Background(), 2*time.Minute)
 	client, err := storage.NewClient(ctx)


### PR DESCRIPTION
There was a series of bugs involving deduplication that were all centered around complications brought about by the stupidity of using BackChars. This replaces all of that with injectable regular expressions and more fine grained prefix support, in the process fixing the deduplication bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/downloader/7)
<!-- Reviewable:end -->
