### PR TITLE
Remove "404 Not Found" files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.11
 
 go_import_path: github.com/m-lab/downloader
 

--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -16,13 +16,9 @@ var maxmindFilenameToDedupeRegexp = regexp.MustCompile(`(.*/).*/.*`)
 var MaxmindURLs []string = []string{
 	"http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz",
 	"http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz",
-	"http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz",
 	"http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNumv6.dat.gz",
 	"http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2v6.zip",
-	"http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip",
-	"http://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV/GeoLiteCity-latest.zip",
 	"http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.csv.gz",
-	"http://geolite.maxmind.com/download/geoip/database/GeoIPCountryCSV.zip",
 	"http://geolite.maxmind.com/download/geoip/database/GeoIPv6.csv.gz",
 	"http://geolite.maxmind.com/download/geoip/database/GeoLite2-City-CSV.zip",
 	"http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country-CSV.zip",

--- a/download/maxmind_test.go
+++ b/download/maxmind_test.go
@@ -42,7 +42,7 @@ func TestDownloadMaxmindFiles(t *testing.T) {
 	for _, test := range tests {
 		res := d.DownloadMaxmindFiles(test.urls, test.timestamp, test.fsto)
 		if (res == nil && test.res != nil) || (res != nil && test.res == nil) {
-			t.Errorf("Expected %s, got %s for %+v\n\n, file sto: %+v, fstoaddr: ", test.res, res, test, test.fsto, &test.fsto)
+			t.Errorf("Expected %s, got %s for %+v\n\n, file sto: %+v, fstoaddr: %+v", test.res, res, test, test.fsto, &test.fsto)
 		}
 	}
 


### PR DESCRIPTION
Several files were discontinued on 2019/01/01 and the downloader is already downloading their replacements.

This change simply removes the redundant downloads of the legacy names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/downloader/20)
<!-- Reviewable:end -->
