### PR TITLE
remove apparently obsolete target

### DIFF
--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -16,7 +16,7 @@ var maxmindFilenameToDedupeRegexp = regexp.MustCompile(`(.*/).*/.*`)
 var MaxmindURLs []string = []string{
 	"http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz",
 	"http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.csv.gz",
-	"http://geolite.maxmind.com/download/geoip/database/GeoIPv6.csv.gz",
+	// "http://geolite.maxmind.com/download/geoip/database/GeoIPv6.csv.gz",   // Obsolete?
 	"http://geolite.maxmind.com/download/geoip/database/GeoLite2-City-CSV.zip",
 	"http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country-CSV.zip",
 	"http://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN-CSV.zip",


### PR DESCRIPTION
Downloader started failing last week because the GeoIPv6 file no longer exists at MaxMind.
This PR comments out that item from the list, with a comment explaining.

I prefer this as an interim step rather than just deleting the line, as it provides easier access to recent changes, instead of hiding them in the history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/downloader/26)
<!-- Reviewable:end -->
