### PR TITLE
Migrate downloader to data-processing cluster and cloudbuild deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 go_import_path: github.com/m-lab/downloader
 
 before_script:
-- go get github.com/mattn/goveralls
+- go install github.com/mattn/goveralls@latest
 
 script:
 - go vet ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- "1.13"
+- "1.18"
 
 go_import_path: github.com/m-lab/downloader
 
@@ -15,45 +15,6 @@ script:
 - go test ./... -race
 - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov
 
-# Cache Gcloud SDK between commands
-cache:
-  directories:
-  - "$HOME/google-cloud-sdk/"
-
 # Install services
 services:
 - docker
-
-before_deploy:
-- $TRAVIS_BUILD_DIR/travis/install_gcloud.sh kubectl
-
-deploy:
-#########################################
-## Sandbox
-- provider: script
-  script: $TRAVIS_BUILD_DIR/deployment/deploy.sh mlab-sandbox data-processing-cluster downloader-mlab-sandbox $GCLOUD_SERVICE_KEY_BOX
-  skip_cleanup: true
-  on:
-    repo: m-lab/downloader
-    all_branches: true
-    condition: $TRAVIS_BRANCH == sandbox-* && $TRAVIS_EVENT_TYPE == push
-
-
-#########################################
-## Staging
-- provider: script
-  script: $TRAVIS_BUILD_DIR/deployment/deploy.sh mlab-staging data-processing-cluster downloader-mlab-staging $GCLOUD_SERVICE_KEY_STG
-  skip_cleanup: true
-  on:
-    repo: m-lab/downloader
-    branch: master
-
-#########################################
-## Production
-- provider: script
-  script: $TRAVIS_BUILD_DIR/deployment/deploy.sh mlab-oti data-processing-cluster downloader-mlab-oti $GCLOUD_SERVICE_KEY_PRD
-  skip_cleanup: true
-  on:
-    repo: m-lab/downloader
-    all_branches: true
-    condition: $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as builder
+FROM golang:1.18 as builder
 # Set up the build environment
 ENV CGO_ENABLED 0
 # Copy files to correct gopath
@@ -14,7 +14,7 @@ RUN go install \
 
 
 # Set up the image we will eventually use
-FROM alpine
+FROM alpine:3.15
 # By default, alpine has no root certs.  We need them for authenticating to GCS.
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -19,6 +19,6 @@ WORKDIR $GOPATH
 RUN apt-get update
 RUN apt-get install -y jq gcc netcat
 RUN apt install ca-certificates libgnutls30 -y
-RUN go install -v github.com/m-lab/gcp-config/cmd/cbif
+RUN go install -v github.com/m-lab/gcp-config/cmd/cbif@latest
 
 ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,0 +1,24 @@
+FROM gcr.io/cloud-builders/gcloud
+
+# Fetch recent go version.
+ENV GOLANG_VERSION 1.18.2
+ENV GOLANG_DOWNLOAD_URL https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+    && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+    && tar -C /usr/local/ -xzf golang.tar.gz \
+    && rm golang.tar.gz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+# Install binaries needed for builds and testing.
+RUN apt-get update
+RUN apt-get install -y jq gcc netcat
+RUN apt install ca-certificates libgnutls30 -y
+RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
+
+ENTRYPOINT ["/go/bin/cbif"]

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -19,6 +19,6 @@ WORKDIR $GOPATH
 RUN apt-get update
 RUN apt-get install -y jq gcc netcat
 RUN apt install ca-certificates libgnutls30 -y
-RUN go get -v github.com/m-lab/gcp-config/cmd/cbif
+RUN go install -v github.com/m-lab/gcp-config/cmd/cbif
 
 ENTRYPOINT ["/go/bin/cbif"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,20 @@ kubectl create secret generic \
 The default cluster size is enough for the downloader, but you need to be sure
 to give it read/write permissions for GCS when you create the cluster.
 
-However, for prometheus monitoring, you must make an extra node pool, as
+So, we create a dedicated node pool with storage-rw permissions. Ultimately, a
+limited permission service account would be preferable. Initially, three nodes
+will be allocated, but the autoscaler will shutdown two after the downloader
+is deployed.
+
+```sh
+gcloud --project=mlab-sandbox container node-pools create downloader-pool \
+  --cluster=data-processing   --num-nodes=1   --region=us-east1 \
+  --scopes storage-rw \
+  --node-labels=downloader-node=true --enable-autorepair --enable-autoupgrade \
+  --machine-type=n1-standard-2
+```
+
+For prometheus monitoring, you must make an extra node pool, as
 described in the readme of the prometheus-support repository.
 
 ## Pub/Sub Topic
@@ -70,3 +83,4 @@ some prometheus metrics on /metrics, the containers will have the label so that
 prometheus scrapes them, and that if you are creating a new cluster for
 downloader, you must follow the setup instructions in the prometheus-support
 repo's readme.
+

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to give it read/write permissions for GCS when you create the cluster.
 
 So, we create a dedicated node pool with storage-rw permissions. Ultimately, a
 limited permission service account would be preferable. Initially, three nodes
-will be allocated, but the autoscaler will shutdown two after the downloader
+will be allocated, but the autoscaler will shut down two after the downloader
 is deployed.
 
 ```sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,9 +47,8 @@ steps:
   ]
   env:
   - PROJECT_NAME=$PROJECT_ID
-  - CLUSTER_NAME=data-processing
   - BUCKET_NAME=downloader-$PROJECT_ID
   - MAXMIND_LICENSE_KEY=$_MAXMIND_LICENSE_KEY
   # For the kubectl docker image script.
-  - CLOUDSDK_COMPUTE_REGION=us-east1
+  - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
   - CLOUDSDK_CONTAINER_CLUSTER=data-processing

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -60,4 +60,4 @@ steps:
   - MAXMIND_LICENSE_KEY=$_MAXMIND_LICENSE_KEY
   # For the kubectl docker image script.
   - CLOUDSDK_COMPUTE_REGION=us-east1
-  - CLOUDSDK_CONTAINER_CLUSTER=downloader-$PROJECT_ID
+  - CLOUDSDK_CONTAINER_CLUSTER=data-processing

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,14 +7,6 @@ options:
   - GIT_COMMIT=$COMMIT_SHA
 
 steps:
-# Fetch travis submodule.
-- name: gcr.io/cloud-builders/git
-  id: "Unshallow git clone"
-  args: ["fetch", "--unshallow"]
-- name: gcr.io/cloud-builders/git
-  id: "Update travis submodule"
-  args: ["submodule", "update", "--init", "--recursive"]
-
 # Run tests.
 - name: gcr.io/cloud-builders/docker
   id: "Build the testing docker container"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
   - go test ./... -race
   env:
   - WORKSPACE_LINK=/go/src/github.com/m-lab/downloader
+  - MAXMIND_LICENSE_KEY=$_MAXMIND_LICENSE_KEY
 
 # Build and deploy.
 - name: gcr.io/cloud-builders/docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,59 @@
+timeout: 1800s
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+  env:
+  - PROJECT_ID=$PROJECT_ID
+  - GIT_COMMIT=$COMMIT_SHA
+
+steps:
+# Fetch travis submodule.
+- name: gcr.io/cloud-builders/git
+  id: "Unshallow git clone"
+  args: ["fetch", "--unshallow"]
+- name: gcr.io/cloud-builders/git
+  id: "Update travis submodule"
+  args: ["submodule", "update", "--init", "--recursive"]
+
+# Run tests.
+- name: gcr.io/cloud-builders/docker
+  id: "Build the testing docker container"
+  args: [
+    "build", "-t", "downloader-testing", "-f", "Dockerfile.testing", "."
+  ]
+- name: downloader-testing
+  id: "Run all downloader unit tests"
+  args:
+  - go version
+  - go vet ./...
+  - go get -v -t ./...
+  - go build ./...
+  - go test ./...
+  - go test ./... -race
+  env:
+  - WORKSPACE_LINK=/go/src/github.com/m-lab/downloader
+
+# Build and deploy.
+- name: gcr.io/cloud-builders/docker
+  id: "Build the downloader docker container"
+  args: [
+    "build", "-t", "gcr.io/$PROJECT_ID/downloader:${COMMIT_SHA}", "."
+  ]
+
+- name: gcr.io/cloud-builders/docker
+  id: "Push the docker container to gcr.io"
+  args: [
+    "push", "gcr.io/$PROJECT_ID/downloader:${COMMIT_SHA}"
+  ]
+
+- name: gcr.io/cloud-builders/kubectl
+  id: "Deploy downloader configuration"
+  entrypoint: /bin/bash
+  args: [
+   '-c', '/builder/kubectl.bash version && ./deployment/deploy.sh'
+  ]
+  env:
+  - PROJECT_NAME=$PROJECT_ID
+  - CLUSTER_NAME=data-processing
+  - BUCKET_NAME=downloader-$PROJECT_ID
+  - MAXMIND_LICENSE_KEY=$_MAXMIND_LICENSE_KEY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -58,3 +58,6 @@ steps:
   - CLUSTER_NAME=data-processing
   - BUCKET_NAME=downloader-$PROJECT_ID
   - MAXMIND_LICENSE_KEY=$_MAXMIND_LICENSE_KEY
+  # For the kubectl docker image script.
+  - CLOUDSDK_COMPUTE_REGION=us-east1
+  - CLOUDSDK_CONTAINER_CLUSTER=downloader-$PROJECT_ID

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -18,6 +18,5 @@ MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY:?Please specify the \$MAXMIND_LICENSE_
 ./travis/substitute_values.sh ./deployment/templates/ GITHUB_COMMIT \
     ${GIT_COMMIT} PROJECT_NAME ${PROJECT_NAME} BUCKET_NAME ${BUCKET_NAME}
 
-
 ./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl apply \
     -f ./deployment/templates/deploy-downloader.yaml

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -12,7 +12,7 @@ kubectl create \
     --from-literal=license_key=${MAXMIND_LICENSE_KEY} \
     --dry-run -o json | kubectl apply -f -
 
-find ./deployment/templates/ -a -type f -a -print -a \
+find ./deployment/templates/ -type f -a -print -a \
    -exec sed \
        --expression="s|{{GITHUB_COMMIT}}|${GIT_COMMIT}|" \
        --expression="s|{{PROJECT_NAME}}|${PROJECT_NAME}|" \

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -17,6 +17,6 @@ find ./deployment/templates/ -a -type f -a -print -a \
        --expression="s|{{GITHUB_COMMIT}}|${GIT_COMMIT}|" \
        --expression="s|{{PROJECT_NAME}}|${PROJECT_NAME}|" \
        --expression="s|{{BUCKET_NAME}}|${BUCKET_NAME}|" \
-       --in-place $f
+       --in-place {} \;
 
 kubectl apply -f ./deployment/templates/deploy-downloader.yaml

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -2,25 +2,21 @@
 set -e
 set -x
 
-USAGE="$0 <project name> <cluster name> <bucket name> <base64 service account key text>"
-PROJECT_NAME=${1:?Please provide a project name: $USAGE}
-CLUSTER_NAME=${2:?Please specify the name of the cluster: $USAGE}
-BUCKET_NAME=${3:?Please specify the name of the bucket where you want files saved: $USAGE}
-GCLOUD_SERVICE_KEY=${4:?Please enter the base64 encoded json keyfile: $USAGE}
-
-echo $GCLOUD_SERVICE_KEY | base64 --decode -i > /tmp/${PROJECT_NAME}.json
-gcloud auth activate-service-account --key-file /tmp/${PROJECT_NAME}.json
+PROJECT_NAME=${PROJECT_NAME:?Please provide a \$PROJECT_NAME}
+CLUSTER_NAME=${CLUSTER_NAME:?Please specify the \$CLUSTER_NAME}
+BUCKET_NAME=${BUCKET_NAME:?Please specify the \$BUCKET_NAME where you want files saved}
+MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY:?Please specify the \$MAXMIND_LICENSE_KEY}
 
 ./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl create \
-  secret generic downloader-secret --from-literal=license_key=$MAXMIND_LICENSE_KEY \
-  --from-file=key.json=/tmp/${PROJECT_NAME}.json \
-  --dry-run -o json | ./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl apply -f -
+  secret generic downloader-secret \
+    --from-literal=license_key=$MAXMIND_LICENSE_KEY \
+    --dry-run -o json | ./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl apply -f -
 
 ./travis/build_and_push_container.sh \
-    gcr.io/${PROJECT_NAME}/downloader:$TRAVIS_COMMIT $PROJECT_NAME
+    gcr.io/${PROJECT_NAME}/downloader:$GIT_COMMIT $PROJECT_NAME
 
 ./travis/substitute_values.sh ./deployment/templates/ GITHUB_COMMIT \
-    $TRAVIS_COMMIT PROJECT_NAME ${PROJECT_NAME} BUCKET_NAME ${BUCKET_NAME}
+    ${GIT_COMMIT} PROJECT_NAME ${PROJECT_NAME} BUCKET_NAME ${BUCKET_NAME}
 
 
 ./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl apply \

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -12,7 +12,11 @@ kubectl create \
     --from-literal=license_key=${MAXMIND_LICENSE_KEY} \
     --dry-run -o json | kubectl apply -f -
 
-./travis/substitute_values.sh ./deployment/templates/ GITHUB_COMMIT \
-    ${GIT_COMMIT} PROJECT_NAME ${PROJECT_NAME} BUCKET_NAME ${BUCKET_NAME}
+find ./deployment/templates/ -a -type f -a -print -a \
+   -exec sed \
+       --expression="s|{{GITHUB_COMMIT}}|${GIT_COMMIT}|" \
+       --expression="s|{{PROJECT_NAME}}|${PROJECT_NAME}|" \
+       --expression="s|{{BUCKET_NAME}}|${BUCKET_NAME}|" \
+       --in-place $f
 
 kubectl apply -f ./deployment/templates/deploy-downloader.yaml

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -2,21 +2,17 @@
 set -e
 set -x
 
+GIT_COMMIT=${GIT_COMMIT:?Please provide a \$GIT_COMMIT}
 PROJECT_NAME=${PROJECT_NAME:?Please provide a \$PROJECT_NAME}
-CLUSTER_NAME=${CLUSTER_NAME:?Please specify the \$CLUSTER_NAME}
 BUCKET_NAME=${BUCKET_NAME:?Please specify the \$BUCKET_NAME where you want files saved}
 MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY:?Please specify the \$MAXMIND_LICENSE_KEY}
 
-./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl create \
+kubectl create \
   secret generic downloader-secret \
-    --from-literal=license_key=$MAXMIND_LICENSE_KEY \
-    --dry-run -o json | ./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl apply -f -
-
-./travis/build_and_push_container.sh \
-    gcr.io/${PROJECT_NAME}/downloader:$GIT_COMMIT $PROJECT_NAME
+    --from-literal=license_key=${MAXMIND_LICENSE_KEY} \
+    --dry-run -o json | kubectl apply -f -
 
 ./travis/substitute_values.sh ./deployment/templates/ GITHUB_COMMIT \
     ${GIT_COMMIT} PROJECT_NAME ${PROJECT_NAME} BUCKET_NAME ${BUCKET_NAME}
 
-./travis/kudo.sh $PROJECT_NAME $CLUSTER_NAME kubectl apply \
-    -f ./deployment/templates/deploy-downloader.yaml
+kubectl apply -f ./deployment/templates/deploy-downloader.yaml

--- a/deployment/templates/deploy-downloader.yaml
+++ b/deployment/templates/deploy-downloader.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/deployment/templates/deploy-downloader.yaml
+++ b/deployment/templates/deploy-downloader.yaml
@@ -35,8 +35,6 @@ spec:
           value: "{{BUCKET_NAME}}"
         - name: PROJECT_NAME
           value: {{PROJECT_NAME}}
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/secrets/google/key.json
         - name: MAXMIND_LICENSE_KEY
           valueFrom:
             secretKeyRef:

--- a/deployment/templates/deploy-downloader.yaml
+++ b/deployment/templates/deploy-downloader.yaml
@@ -55,4 +55,4 @@ spec:
       securityContext: {}
       terminationGracePeriodSeconds: 30
       nodeSelector:
-        parser-node: "true"
+        downloader-node: "true"

--- a/deployment/templates/deploy-downloader.yaml
+++ b/deployment/templates/deploy-downloader.yaml
@@ -41,9 +41,6 @@ spec:
               name: downloader-secret
               key: license_key
         image: gcr.io/{{PROJECT_NAME}}/downloader:{{GITHUB_COMMIT}}
-        volumeMounts:
-          - name: google-cloud-key
-            mountPath: /var/secrets/google
         imagePullPolicy: IfNotPresent
         name: downloader
         ports:
@@ -57,4 +54,5 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
-
+      nodeSelector:
+        parser-node: "true"

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,41 @@
 module github.com/m-lab/downloader
 
-go 1.13
+go 1.18
 
 require (
-	cloud.google.com/go/pubsub v1.1.0
 	cloud.google.com/go/storage v1.5.0
-	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 // indirect
 	github.com/m-lab/go v1.2.1
 	github.com/prometheus/client_golang v1.3.0
-	github.com/prometheus/prometheus v2.5.0+incompatible // indirect
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
 	google.golang.org/api v0.15.0
+)
+
+require (
+	cloud.google.com/go v0.50.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/go-test/deep v1.0.8 // indirect
+	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/prometheus/client_model v0.1.0 // indirect
+	github.com/prometheus/common v0.7.0 // indirect
+	github.com/prometheus/procfs v0.0.8 // indirect
+	github.com/prometheus/prometheus v2.5.0+incompatible // indirect
+	go.opencensus.io v0.22.2 // indirect
+	golang.org/x/exp v0.0.0-20191227195350-da58074b4299 // indirect
+	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
+	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
+	golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4 // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb // indirect
+	google.golang.org/grpc v1.26.0 // indirect
+	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,9 +7,10 @@ cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTj
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0 h1:0E3eE8MX426vUOs7aHfI7aN1BrIzzzf4ccKCSfSjGmc=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
-cloud.google.com/go v0.51.0 h1:PvKAVQWCtlGUSlZkGW3QLelKaWq7KYv/MW1EboG8bfM=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
+cloud.google.com/go/bigquery v1.3.0 h1:sAbMqjY1PEQKZBWfbu6Y6bsupJ9c4QdHnzg/VvYTLcE=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
+cloud.google.com/go/datastore v1.0.0 h1:Kt+gOPPp2LEPWp8CSfxhsM8ik9CcyE/gYu+0r+RnZvM=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0 h1:9/vpR43S4aJaROxqQHQ3nH9lfyKKV0dC3vOmnw8ebQQ=
@@ -36,6 +37,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -46,7 +48,10 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 h1:5ZkaAPbicIKTF2I64qf5Fh8Aa83Q/dnOafMYV0OMwjA=
@@ -65,6 +70,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -80,6 +86,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 h1:Iy7Ifq2ysilWU4QlCx/97OoI4xT1IV7i8byT/EyIT/M=
+github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4ufZiIGv2nXn4gMxnfKV306n3mWXgNu/d2TqdTU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -97,6 +105,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -114,7 +123,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/prometheus/prometheus v1.8.2 h1:PAL466mnJw1VolZPm1OarpdUpqukUy/eX4tagia17DM=
 github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
 github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -124,6 +132,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -267,6 +276,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
To fully decommission the v1 data pipeline we would like to delete the `data-processing-cluster` GKE cluster. The last remaining service running there is the `downloader` which is responsible for fetching current maxmind and routeview databases and storing them in GCS.

This change updates the deployment to use cloudbuild.yaml and targets the `data-processing` cluster, now home to the v2 data pipeline.

The deployment depends on a new node pool (with a single node) provisioned with read-write scopes to the GCS APIs, to allow writing results to GCS. The cloud build deployment also depends on setting build environment variables for `_MAXMIND_LICENSE_KEY` and `_CLUSTER_REGION`. These must be created before merging this change.

Tested by reviewing prometheus metrics from the downloader:
* http://prometheus-data-processing.mlab-sandbox.measurementlab.net:9090/graph?g0.expr=downloader_last_success_time_seconds&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=2d&g1.expr=downloader_error_total%7Bcontainer%3D%22downloader%22%7D&g1.tab=0&g1.stacked=0&g1.show_exemplars=0&g1.range_input=2d
* In prometheus federation due to https://github.com/m-lab/prometheus-support/pull/907
* Updates to all `current` folders in GCS gs://downloader-mlab-sandbox/ e.g. gs://downloader-mlab-sandbox/RouteViewIPv6/current

Part of:
* https://github.com/m-lab/etl/issues/1074

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/downloader/44)
<!-- Reviewable:end -->
