### PR TITLE
Use HTTP Basic Auth when downloading MaxMind databases

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
   env:
   - WORKSPACE_LINK=/go/src/github.com/m-lab/downloader
   - MAXMIND_LICENSE_KEY=$_MAXMIND_LICENSE_KEY
+  - MAXMIND_ACCOUNT_ID=$_MAXMIND_ACCOUNT_ID
 
 # Build and deploy.
 - name: gcr.io/cloud-builders/docker
@@ -49,6 +50,7 @@ steps:
   - PROJECT_NAME=$PROJECT_ID
   - BUCKET_NAME=downloader-$PROJECT_ID
   - MAXMIND_LICENSE_KEY=$_MAXMIND_LICENSE_KEY
+  - MAXMIND_ACCOUNT_ID=$_MAXMIND_ACCOUNT_ID
   # For the kubectl docker image script.
   - CLOUDSDK_COMPUTE_REGION=$_CLUSTER_REGION
   - CLOUDSDK_CONTAINER_CLUSTER=$_CLUSTER_NAME

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -6,6 +6,7 @@ GIT_COMMIT=${GIT_COMMIT:?Please provide a \$GIT_COMMIT}
 PROJECT_NAME=${PROJECT_NAME:?Please provide a \$PROJECT_NAME}
 BUCKET_NAME=${BUCKET_NAME:?Please specify the \$BUCKET_NAME where you want files saved}
 MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY:?Please specify the \$MAXMIND_LICENSE_KEY}
+MAXMIND_ACCOUNT_ID=${MAXMIND_ACCOUNT_ID:?Please specify the \$MAXMIND_ACCOUNT_ID}
 
 kubectl create \
   secret generic downloader-secret \

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -10,6 +10,7 @@ MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY:?Please specify the \$MAXMIND_LICENSE_
 kubectl create \
   secret generic downloader-secret \
     --from-literal=license_key=${MAXMIND_LICENSE_KEY} \
+    --from-literal=account_id=${MAXMIND_ACCOUNT_ID} \
     --dry-run -o json | kubectl apply -f -
 
 find ./deployment/templates/ -type f -a -print -a \

--- a/deployment/templates/deploy-downloader.yaml
+++ b/deployment/templates/deploy-downloader.yaml
@@ -40,6 +40,11 @@ spec:
             secretKeyRef:
               name: downloader-secret
               key: license_key
+        - name: MAXMIND_ACCOUNT_ID
+          valueFrom:
+            secretKeyRef:
+              name: downloader-secret
+              key: account_id
         image: gcr.io/{{PROJECT_NAME}}/downloader:{{GITHUB_COMMIT}}
         imagePullPolicy: IfNotPresent
         name: downloader

--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -18,28 +18,28 @@ var maxmindDownloadInfo = []struct {
 	current  string
 }{
 	{
-		url:      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&suffix=tar.gz&license_key=",
+		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-ASN/download?suffix=tar.gz",
 		filename: "GeoLite2-ASN.tar.gz",
 	},
 	{
-		url:      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN-CSV&suffix=zip&license_key=",
+		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-ASN-CSV/download?suffix=zip",
 		filename: "GeoLite2-ASN-CSV.zip",
 	},
 	{
-		url:      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&suffix=tar.gz&license_key=",
+		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz",
 		filename: "GeoLite2-City.tar.gz",
 		current:  "Maxmind/current/GeoLite2-City.tar.gz",
 	},
 	{
-		url:      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City-CSV&suffix=zip&license_key=",
+		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-City-CSV/download?suffix=zip",
 		filename: "GeoLite2-City-CSV.zip",
 	},
 	{
-		url:      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&suffix=tar.gz&license_key=",
+		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz",
 		filename: "GeoLite2-Country.tar.gz",
 	},
 	{
-		url:      "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&suffix=zip&license_key=",
+		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-Country-CSV/download?suffix=zip",
 		filename: "GeoLite2-Country-CSV.zip",
 	},
 }
@@ -49,11 +49,11 @@ var maxmindDownloadInfo = []struct {
 // interface where the user wants the files stored. It then downloads the files,
 // stores them, and returns and error on failure or nil on success. Guaranteed
 // to not introduce duplicates.
-func MaxmindFiles(ctx context.Context, timestamp string, store file.Store, maxmindLicenseKey string) error {
+func MaxmindFiles(ctx context.Context, timestamp string, store file.Store, maxmindLicenseKey string, maxmindAccountID string) error {
 	var lastErr error
 	for _, info := range maxmindDownloadInfo {
 		dc := config{
-			URL:           info.url + maxmindLicenseKey,
+			URL:           info.url,
 			Store:         store,
 			PathPrefix:    "Maxmind/" + timestamp,
 			CurrentName:   info.current,
@@ -61,6 +61,8 @@ func MaxmindFiles(ctx context.Context, timestamp string, store file.Store, maxmi
 			FixedFilename: info.filename,
 			DedupRegexp:   maxmindFilenameToDedupRegexp,
 			MaxDuration:   *downloadTimeout,
+			BasicAuthUser: maxmindAccountID,
+			BasicAuthPass: maxmindLicenseKey,
 		}
 		if err := runFunctionWithRetry(ctx, download, dc, *waitAfterFirstDownloadFailure, *maximumWaitBetweenDownloadAttempts); err != nil {
 			lastErr = err

--- a/download/maxmind_test.go
+++ b/download/maxmind_test.go
@@ -12,15 +12,31 @@ import (
 // TODO: Distribute the configuration and code separately.
 func TestAllMaxmindURLs(t *testing.T) {
 	for index := range maxmindDownloadInfo {
+		user, found := os.LookupEnv("MAXMIND_ACCOUNT_ID")
+		if !found {
+			t.Error("Could not load Maxmind account ID from ${MAXMIND_ACCOUNT_ID}")
+			return
+		}
 		key, found := os.LookupEnv("MAXMIND_LICENSE_KEY")
 		if !found {
 			t.Error("Could not load Maxmind license key from ${MAXMIND_LICENSE_KEY}")
 			return
 		}
-		u := maxmindDownloadInfo[index].url + key
-		resp, err := http.Head(u)
+
+		url := maxmindDownloadInfo[index].url
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			t.Errorf("http.NewRequest() failed for %q: %v ", url, err)
+		}
+
+		req.Close = true
+		req.SetBasicAuth(user, key)
+
+		client := http.Client{}
+		resp, err := client.Do(req)
+
 		if err != nil || resp.StatusCode != http.StatusOK {
-			t.Errorf("Bad URL (%q), err: %v (%v)", u, err, resp.StatusCode)
+			t.Errorf("Bad URL (%q), err: %v (%v)", url, err, resp.StatusCode)
 		}
 	}
 }

--- a/downloader.go
+++ b/downloader.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"log"
-	"math/rand"
 	"time"
 
 	"github.com/m-lab/go/flagx"
@@ -39,6 +38,7 @@ func main() {
 	bucketName := flag.String("bucket", "", "Specify the bucket name to store the results in.")
 	projectName := flag.String("project", "", "Specify the project name to send the pub/sub in.")
 	maxmindLicenseKey := flag.String("maxmind_license_key", "", "the license key for maxmind downloading.")
+	maxmindAccountID := flag.String("maxmind_account_id", "", "the account ID for maxmind downloading.")
 
 	flag.Parse()
 	flagx.ArgsFromEnv(flag.CommandLine)
@@ -49,15 +49,14 @@ func main() {
 	if *projectName == "" {
 		log.Fatal("NO PROJECT SPECIFIED!!!")
 	}
-	rand.Seed(time.Now().UTC().UnixNano())
 	prometheusx.MustServeMetrics()
-	loopOverURLsForever(mainCtx, *bucketName, *maxmindLicenseKey)
+	loopOverURLsForever(mainCtx, *bucketName, *maxmindLicenseKey, *maxmindAccountID)
 }
 
 // loopOverURLsForever takes a bucketName, pointing to a GCS bucket,
 // and then tries to download the files over and over again until the
 // end of time (waiting an average of 8 hours in between attempts)
-func loopOverURLsForever(ctx context.Context, bucketName string, maxmindLicenseKey string) {
+func loopOverURLsForever(ctx context.Context, bucketName string, maxmindLicenseKey string, maxmindAccountID string) {
 	// TODO: consider migrating to github.com/m-lab/go/memoryless
 	lastDownloadedV4 := 0
 	lastDownloadedV6 := 0
@@ -69,7 +68,7 @@ func loopOverURLsForever(ctx context.Context, bucketName string, maxmindLicenseK
 		}
 		fileStore := file.NewGCSStore(bkt)
 
-		maxmindErr := download.MaxmindFiles(ctx, timestamp, fileStore, maxmindLicenseKey)
+		maxmindErr := download.MaxmindFiles(ctx, timestamp, fileStore, maxmindLicenseKey, maxmindAccountID)
 		if maxmindErr != nil {
 			log.Println(maxmindErr)
 		}


### PR DESCRIPTION
We received an email from MaxMind to support@ warning us that in a month or two all database download requests would redirect to some Cloudflare domain using "R2 presigned URL", and that it _could_ be a breaking change if your client doesn't support redirects and/or HTTPS. It turns out that our client does support all that. However, as I was looking into the URLs we are using for downloads I noticed that they are using a format that is very different from what MaxMind seems to be currently telling you to do. Not only did the URLs apparently change, but MaxMind now wants you to use HTTP Basic Auth in your requests for database files, as opposed to just appending a `license_key` query parameter to requests (which is what downloader does today).

This PR updates the MaxMind download URLs to the ones that MaxMind is currently recommending, and it also implements HTTP Basic Auth for MaxMind download requests.

Also, while I had vscode open, I noticed a warning that `rand.Seed()` is deprecated in Go >=1.20, so I went ahead and removed that line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/downloader/54)
<!-- Reviewable:end -->
