### PR TITLE
Removes all Maxmind database download except GeoLite2-City

### DIFF
--- a/download/maxmind.go
+++ b/download/maxmind.go
@@ -18,29 +18,9 @@ var maxmindDownloadInfo = []struct {
 	current  string
 }{
 	{
-		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-ASN/download?suffix=tar.gz",
-		filename: "GeoLite2-ASN.tar.gz",
-	},
-	{
-		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-ASN-CSV/download?suffix=zip",
-		filename: "GeoLite2-ASN-CSV.zip",
-	},
-	{
 		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz",
 		filename: "GeoLite2-City.tar.gz",
 		current:  "Maxmind/current/GeoLite2-City.tar.gz",
-	},
-	{
-		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-City-CSV/download?suffix=zip",
-		filename: "GeoLite2-City-CSV.zip",
-	},
-	{
-		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-Country/download?suffix=tar.gz",
-		filename: "GeoLite2-Country.tar.gz",
-	},
-	{
-		url:      "https://download.maxmind.com/geoip/databases/GeoLite2-Country-CSV/download?suffix=zip",
-		filename: "GeoLite2-Country-CSV.zip",
 	},
 }
 


### PR DESCRIPTION
For some reason that probably goes back 7 or 8 years, downloader has been configured to download a bunch of GeoLite2 databases, even though the only one we are currently using is apparently the GeoLite2-City database. These days Maxmind has implemented a download quota for the GeoLite2 databases of 30/day. Downloading the previous 6 databases in every project every day, already puts us at 18 downloads/day. If downloader is restarted for any reason, it automatically downloads everything again, even if it was already downloaded that day, which pushes us past the quota. Rather than trying to implement timestamp checking on the most recently downloaded files on every start of downloader, just downloading the single file we actually use seems easier and better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/downloader/56)
<!-- Reviewable:end -->
